### PR TITLE
Fix key error caused by an airwave system with no access points.

### DIFF
--- a/airwaveapiclient/airwaveapiclient.py
+++ b/airwaveapiclient/airwaveapiclient.py
@@ -356,8 +356,9 @@ class APList(list):
 
         """
         data = xmltodict.parse(xml)
-        obj = data['amp:amp_ap_list']['ap']
-        list.__init__(self, obj)
+        if 'ap' in data['amp:amp_ap_list']:
+            obj = data['amp:amp_ap_list']['ap']
+            list.__init__(self, obj)
 
     def search(self, obj):
         """Search Access Point.


### PR DESCRIPTION
An airwave system with no access points will return a valid XML document for an ap_list() query.  However, when this document is parsed with APList, a python error will occur due to missing AP elements in the document.  Verify the existence of the key before trying to build the list.  Return an empty list if it doesn't exist.